### PR TITLE
remove redundant code, type migration from Set to TreeSet

### DIFF
--- a/src/main/java/com/sparta/eng80/onetoonetracker/controllers/TrainerController.java
+++ b/src/main/java/com/sparta/eng80/onetoonetracker/controllers/TrainerController.java
@@ -4,6 +4,7 @@ import com.sparta.eng80.onetoonetracker.entities.GroupEntity;
 import com.sparta.eng80.onetoonetracker.entities.TraineeEntity;
 import com.sparta.eng80.onetoonetracker.entities.TrainerEntity;
 import com.sparta.eng80.onetoonetracker.services.GroupService;
+import com.sparta.eng80.onetoonetracker.services.TraineeService;
 import com.sparta.eng80.onetoonetracker.services.TrainerService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -16,9 +17,11 @@ import java.util.Optional;
 public class TrainerController {
 
     private final TrainerService trainerService;
+    private final TraineeService traineeService;
 
-    public TrainerController(TrainerService trainerService, GroupService groupService) {
+    public TrainerController(TrainerService trainerService, TraineeService traineeService) {
         this.trainerService = trainerService;
+        this.traineeService = traineeService;
     }
 
     @GetMapping("trainer/{trainerId}")
@@ -29,7 +32,8 @@ public class TrainerController {
             //trainer id isn't valid, return empty list
         } else {
             GroupEntity groupEntity = trainer.get().getGroup();
-            trainees = trainerService.getAllTraineesFromGroup(groupEntity);
+            trainees = traineeService.findByGroupId(groupEntity.getGroupId());
+
         }
         model.addAttribute("traineesInTrainerGroup", trainees);
         return model;

--- a/src/main/java/com/sparta/eng80/onetoonetracker/entities/TraineeEntity.java
+++ b/src/main/java/com/sparta/eng80/onetoonetracker/entities/TraineeEntity.java
@@ -2,6 +2,7 @@ package com.sparta.eng80.onetoonetracker.entities;
 
 import javax.persistence.*;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * An Entity class represents and stores data from the trainee table
@@ -41,7 +42,7 @@ public class TraineeEntity {
      * All the feedback forms that are related to the trainee
      * @see FeedbackEntity
      */
-    private Set<FeedbackEntity> feedbacks;
+    private TreeSet<FeedbackEntity> feedbacks;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -100,6 +101,6 @@ public class TraineeEntity {
     }
 
     public void setFeedbacks(Set<FeedbackEntity> feedbacks) {
-        this.feedbacks = feedbacks;
+        this.feedbacks = (TreeSet<FeedbackEntity>) feedbacks;
     }
 }

--- a/src/main/java/com/sparta/eng80/onetoonetracker/services/TraineeService.java
+++ b/src/main/java/com/sparta/eng80/onetoonetracker/services/TraineeService.java
@@ -1,5 +1,6 @@
 package com.sparta.eng80.onetoonetracker.services;
 
+import com.sparta.eng80.onetoonetracker.entities.FeedbackEntity;
 import com.sparta.eng80.onetoonetracker.entities.TraineeEntity;
 import com.sparta.eng80.onetoonetracker.repositories.TraineeRepository;
 import com.sparta.eng80.onetoonetracker.services.interfaces.UserAppService;
@@ -7,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 public class TraineeService implements UserAppService<TraineeEntity> {

--- a/src/main/java/com/sparta/eng80/onetoonetracker/services/TrainerService.java
+++ b/src/main/java/com/sparta/eng80/onetoonetracker/services/TrainerService.java
@@ -178,8 +178,4 @@ public class TrainerService implements UserAppService<TrainerEntity> {
         }
         return wasRemoved;
     }
-
-    public Iterable<TraineeEntity> getAllTraineesFromGroup(GroupEntity groupEntity) {
-        return traineeService.findByGroupId(groupEntity.getGroupId());
-    }
 }


### PR DESCRIPTION
- `findByGroupId` was being repeated in `TrainerService` calling upon
- `TraineeService` for no apparent reason, so was refactored. `Set` was also changed to `TreeSet` in `TraineeService` for `feedbacks` to ensure order.