### PR TITLE
fixed border to now show without darkreader

### DIFF
--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -20,7 +20,7 @@
                 </div>
 
                 <div class="d-flex justify-content-center">
-                    <span class="border border-2 shadow p-3 mb-5 bg-body rounded">
+                    <span class="border border-color-main border-2 shadow p-2 mb-3 bg-body rounded">
                         <table class="h5">
                             <tr>
                                 <td class="p-2">Name</td>


### PR DESCRIPTION
Border around the profile details now shows when not using a browser dark mode add-on. 